### PR TITLE
Fix recognising reference parameters for dynamic delegates

### DIFF
--- a/Source/SkookumScriptGenerator/Private/SkookumScriptGenerator.cpp
+++ b/Source/SkookumScriptGenerator/Private/SkookumScriptGenerator.cpp
@@ -2244,7 +2244,7 @@ FString FSkookumScriptGenerator::get_cpp_property_type_name(UProperty * property
     }
 
   if (with_const && property_p->HasAnyPropertyFlags(CPF_ConstParm)) property_type_name = TEXT("const ") + property_type_name;
-  if (with_ref && property_p->HasAnyPropertyFlags(CPF_ReferenceParm)) property_type_name += TEXT(" &");
+  if (with_ref && property_p->HasAnyPropertyFlags(CPF_ReferenceParm | CPF_OutParm)) property_type_name += TEXT(" &");
 
   return property_type_name;
   }


### PR DESCRIPTION
The error case (a bit of a bad practice, but possible) was:

DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FCameraInputRateMultiplier, float&, Multiplier);

The generated script binding would be:

void CameraInputRateMultiplierHook(float Multiplier)

And the binding code would fail to compile because of delegate signature mismatch.

That is because the float parameter, for some reason, was tagged by Unreal as CPF_Parm, CPF_OutParm, but not CPF_ReferenceParm. I'm reasonably certain that this won't cause false-positives.